### PR TITLE
trace-cruncher: Fix CI issue and add reproducibility tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,8 @@ jobs:
         sudo apt-get install libpython3-dev cython3 python3-numpy -y
         sudo apt install python3-pip
         sudo pip3 install --system pkgconfig GitPython
-        bash scripts/date-snapshot/date-snapshot.sh -f scripts/date-snapshot/repos
+        cd ./scripts/date-snapshot/
+        bash ./date-snapshot.sh -f ./repos
         cd libtraceevent
         make
         sudo make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install Dependencies
+      working-directory: ${{runner.workspace}}/trace-cruncher
       shell: bash
       run: |
         sudo apt-get update
@@ -21,22 +22,19 @@ jobs:
         sudo apt-get install libpython3-dev cython3 python3-numpy -y
         sudo apt install python3-pip
         sudo pip3 install --system pkgconfig GitPython
-        git clone https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/
+        bash scripts/date-snapshot/date-snapshot.sh -f scripts/date-snapshot/repos
         cd libtraceevent
         make
         sudo make install
         cd ..
-        git clone https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/
         cd libtracefs
         make
         sudo make install
         cd ..
-        git clone https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git
         cd trace-cmd
         make
         sudo make install_libs
         cd ..
-        git clone https://github.com/yordan-karadzhov/kernel-shark-v2.beta.git kernel-shark
         cd kernel-shark/build
         cmake ..
         make

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ clean:
 	${RM} $(TC_BASE_LIB)
 	${RM} src/*.o
 	${RM} build
+	bash scripts/date-snapshot/date-snapshot.sh -d -f scripts/date-snapshot/repos
 
 install:
 	@ echo ${CYAN}Installing trace-cruncher:${NC};

--- a/scripts/date-snapshot/date-snapshot.sh
+++ b/scripts/date-snapshot/date-snapshot.sh
@@ -7,40 +7,67 @@
 # Takes inputs specified via command line or in a file
 
 package=date-snapshot
-clean="false" # clean and download define the script's behavior
-download="true"
-# If clean is set, we delete existing repos. If not, we leave them untouched (no checkout).
-# If download is set, we download and checkout the repos specified if they don't exist.
+clean="false" # Delete existing repos
+download="true" # Download and checkout the repos specified if they don't exist
+verbose="false" # Print non-critical debug info and warnings
+latest="false" # Ignore the specified date and get the latest version
 
+# Get absolute path of the folder we're working in, derived from the file path for -f
+# If that command fails, abort
+get_absolute_folder(){
+  name=$(dirname "$1") # directory which contains our input
+  dir_valid=$(if [[ -d "${name}" ]]; then echo "true"; fi) # is this directory valid?
+  cd "${name}" # attempt to cd to that directory
+  if [[ $dir_valid = "true" && $? = "0" ]] ; then # if the directory is valid and cd succeeds
+    echo $(pwd -P)
+  else
+    log_critical "*** Error: Could not get path info for input file."
+  fi
+}
+
+# log_critical always prints for critical information
+log_critical(){
+echo "$1"
+}
+
+# log_verbose only prints when the -v flag is set
+log_verbose(){
+if [[ $verbose = "true" ]] ; then
+echo "$1"
+fi
+}
+
+# the main function to download and checkout the specified repositories
 download_checkout(){
   IN="${1}"
   IFS=';' read -ra ADDR <<< "$IN"
 
   if [[ $clean = "true" ]] ; then # delete the repos if requested
-    if [[ ! -d "${ADDR[0]}" ]] ; then
-      echo "*** Warning: Directory ${ADDR[0]} does not exist, nothing to delete"
+    if [[ ! -d "${workdir}/${ADDR[0]}" ]] ; then
+      log_verbose "*** Warning: Directory ${workdir}/${ADDR[0]} does not exist, nothing to delete"
     else
-      echo "Removing ${ADDR[0]}"
-      rm -rf "./${ADDR[0]}"
+      log_verbose "Removing ${workdir}/${ADDR[0]}"
+      rm -rf "${workdir}/${ADDR[0]}"
     fi
   fi
 
   # if download is true and directory doesn't exist
-  if [[ $download = "true" && ! -d "${ADDR[0]}" ]] ; then
-    git clone -b "${ADDR[2]}" "${ADDR[1]}" "${ADDR[0]}"
-    cd "${ADDR[0]}"
-
-    last_date=`date -d "${ADDR[3]}" +%s` # convert given date to unix timestamp
-    # we could simply give the param to git but it understands fewer formats than date
-
-    # this checks out the first entry in the list of commit hashes which occur before our date
-    git checkout `git log --date=unix --before="${last_date}" --pretty=format:"%H" | head -n 1`
-
-    cd ..
+  if [[ $download = "true" && ! -d "${workdir}/${ADDR[0]}" ]] ; then
+    git clone -b "${ADDR[2]}" "${ADDR[1]}" "${workdir}/${ADDR[0]}"
+    if [[ $latest = "false" ]] ; then # If latest flag is set, leave repo as-is
+      cd "${workdir}/${ADDR[0]}"
+      last_date=`date -d "${ADDR[3]}" +%s` # convert given date to unix timestamp
+      # we could simply give the param to git but it understands fewer formats than date
+      # this checks out the first entry in the list of commit hashes which occur before our date
+      git checkout `git log --date=unix --before="${last_date}" --pretty=format:"%H" | head -n 1`
+      cd "${workdir}"
+    else
+      log_verbose "Latest flag set, skipping checkout for ${ADDR[0]}"
+    fi
   elif [[ $download = "false" ]] ; then
-    echo "Download flag not set, skipping ${ADDR[0]}"
-  elif [[ -d "${ADDR[0]}" ]] ; then
-    echo "Directory exists, skipping ${ADDR[0]}"
+    log_verbose "Download flag not set, skipping ${ADDR[0]}"
+  elif [[ -d "${workdir}/${ADDR[0]}" ]] ; then
+    log_verbose "Directory exists, skipping ${ADDR[0]}"
   fi
 
   unset IFS
@@ -59,6 +86,8 @@ while test $# -gt 0; do
       echo "-h, --help                show brief help"
       echo "-c, --clean               delete the directories specified in the input and continue"
       echo "-d, --delete              delete the directories specified in the input and exit"
+      echo "-v, --verbose             print debugging information to the console"
+      echo "-l, --latest              ignore specified date and checkout the latest versions"
       echo "-i, --input REPOS         specify a space-sep'd list of repos to download"
       echo "-f, --file FILE           specify an input file, one repo per line"
       exit 0
@@ -73,8 +102,17 @@ while test $# -gt 0; do
       clean="true"
       download="false"
       ;;
+    -v|--verbose)
+      shift
+      verbose="true"
+      ;;
+    -l|--latest)
+      shift
+      latest="true"
+      ;;
     -i|--input)
       shift
+      workdir="${pwd}"
       IFS=" "
       while read repo; do
         download_checkout $repo
@@ -84,13 +122,14 @@ while test $# -gt 0; do
       ;;
     -f|--file)
       shift
+      workdir="$(get_absolute_folder "$1")"
       while read line; do
         download_checkout $line
       done <$1
       break
       ;;
     *)
-      echo "Usage: ${package} [-c|--clean] [-d|delete] [-i|--input] [-f|--file] <input>"
+      echo "Usage: ${package} [-c] [-d] [-v] [-l] [-i|--input] [-f|--file] <input>"
       echo "${package} --help for more"
       break
       ;;

--- a/scripts/date-snapshot/date-snapshot.sh
+++ b/scripts/date-snapshot/date-snapshot.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# Script to download one or several git repos at the last commit before a specified date
+# Takes inputs specified via command line or in a file
+# Created by June Knauth (VMware) <june.knauth@gmail.com>, 2022-06-22
+
+package=date-snapshot
+
+download_checkout(){
+  IN="${1}"
+  # $fields=(${IN//;/ }) 
+  IFS=';' read -ra ADDR <<< "$IN"
+  
+  git clone -b ${ADDR[2]} ${ADDR[1]} ${ADDR[0]}
+  cd ${ADDR[0]}
+
+  last_date=`date -d ${ADDR[3]} +%s` # convert given date to unix timestamp
+  # we could simply give the param to git but it understands fewer formats than date
+ 
+  # this checks out the first entry in the list of commit hashes which occur before our date 
+  git checkout `git log --date=unix --before=${last_date} --pretty=format:"%H" | head -n 1`
+   
+  cd .. 
+  unset IFS
+}
+
+while test $# -gt 0; do
+  case "$1" in
+    -h|--help)
+      echo "$package - Download a git repo and checkout the last commit before a given date"
+	  echo "Takes CLI and file arguments with format '<repo name>;<repo url>;<branch>;<date>'"
+      echo "Dates can be provided in any format the unix 'date' command understands."
+      echo " "
+      echo "$package [options] [arguments]"
+      echo " "
+      echo "options:"
+      echo "-h, --help                show brief help"
+      echo "-i, --input REPOS         specify a space-sep'd list of repos to download"
+      echo "-f, --file FILE           specify an input file, one repo per line"
+      exit 0
+      ;;
+    -i|--input)
+      shift
+      IFS=" "
+      while read repo; do
+        download_checkout $repo
+      done <<< $1
+      unset IFS
+      break
+      ;;
+    -f|--file)
+	  shift
+      while read line; do
+      download_checkout $line		
+      done <$1
+	  break
+      ;;
+    *)
+      echo "Usage: ${package} [-s] [-i|--input] [-f|--file]"
+      echo "${package} --help for more"
+      break
+      ;;
+  esac
+done
+

--- a/scripts/date-snapshot/date-snapshot.sh
+++ b/scripts/date-snapshot/date-snapshot.sh
@@ -1,26 +1,44 @@
 #!/bin/bash
-
+#
+# SPDX-License-Identifier: LGPL-2.1
+# Copyright (C) 2022, VMware Inc, June Knauth <june.knauth@gmail.com>
+#
 # Script to download one or several git repos at the last commit before a specified date
 # Takes inputs specified via command line or in a file
-# Created by June Knauth (VMware) <june.knauth@gmail.com>, 2022-06-22
 
 package=date-snapshot
+clean=false # clean and download define the script's behavior
+download=true
+# If clean is set, we delete existing repos. If not, we leave them untouched (no checkout).
+# If download is set, we download and checkout the repos specified if they don't exist.
 
 download_checkout(){
   IN="${1}"
-  # $fields=(${IN//;/ }) 
   IFS=';' read -ra ADDR <<< "$IN"
-  
-  git clone -b ${ADDR[2]} ${ADDR[1]} ${ADDR[0]}
-  cd ${ADDR[0]}
 
-  last_date=`date -d ${ADDR[3]} +%s` # convert given date to unix timestamp
-  # we could simply give the param to git but it understands fewer formats than date
- 
-  # this checks out the first entry in the list of commit hashes which occur before our date 
-  git checkout `git log --date=unix --before=${last_date} --pretty=format:"%H" | head -n 1`
-   
-  cd .. 
+  if $clean ; then # delete the repos if requested
+    echo "Removing ${ADDR[0]}"
+    rm -rf ./${ADDR[0]}
+  fi
+
+  # if download is true and directory doesn't exist
+  if [[ $download = true && ! -d ${ADDR[0]} ]] ; then
+    git clone -b ${ADDR[2]} ${ADDR[1]} ${ADDR[0]}
+    cd ${ADDR[0]}
+
+    last_date=`date -d ${ADDR[3]} +%s` # convert given date to unix timestamp
+    # we could simply give the param to git but it understands fewer formats than date
+
+    # this checks out the first entry in the list of commit hashes which occur before our date
+    git checkout `git log --date=unix --before=${last_date} --pretty=format:"%H" | head -n 1`
+
+    cd ..
+  elif [[ $download = false ]]; then
+    echo "Download flag not set, skipping ${ADDR[0]}"
+  elif [[ -d ${ADDR[0]} ]] ; then
+    echo "Directory exists, skipping ${ADDR[0]}"
+  fi
+
   unset IFS
 }
 
@@ -28,16 +46,28 @@ while test $# -gt 0; do
   case "$1" in
     -h|--help)
       echo "$package - Download a git repo and checkout the last commit before a given date"
-	  echo "Takes CLI and file arguments with format '<repo name>;<repo url>;<branch>;<date>'"
+      echo "Takes CLI and file arguments with format '<repo name>;<repo url>;<branch>;<date>'"
       echo "Dates can be provided in any format the unix 'date' command understands."
       echo " "
       echo "$package [options] [arguments]"
       echo " "
       echo "options:"
       echo "-h, --help                show brief help"
+      echo "-c, --clean               delete the directories specified in the input and continue"
+      echo "-d, --delete              delete the directories specified in the input and exit"
       echo "-i, --input REPOS         specify a space-sep'd list of repos to download"
       echo "-f, --file FILE           specify an input file, one repo per line"
       exit 0
+      ;;
+    -c|--clean)
+      shift
+      clean=true
+      download=true
+      ;;
+    -d|--delete)
+      shift
+      clean=true
+      download=false
       ;;
     -i|--input)
       shift
@@ -49,14 +79,14 @@ while test $# -gt 0; do
       break
       ;;
     -f|--file)
-	  shift
+      shift
       while read line; do
-      download_checkout $line		
+        download_checkout $line
       done <$1
-	  break
+      break
       ;;
     *)
-      echo "Usage: ${package} [-s] [-i|--input] [-f|--file]"
+      echo "Usage: ${package} [-c|--clean] [-d|delete] [-i|--input] [-f|--file] <input>"
       echo "${package} --help for more"
       break
       ;;

--- a/scripts/date-snapshot/date-snapshot.sh
+++ b/scripts/date-snapshot/date-snapshot.sh
@@ -7,8 +7,8 @@
 # Takes inputs specified via command line or in a file
 
 package=date-snapshot
-clean=false # clean and download define the script's behavior
-download=true
+clean="false" # clean and download define the script's behavior
+download="true"
 # If clean is set, we delete existing repos. If not, we leave them untouched (no checkout).
 # If download is set, we download and checkout the repos specified if they don't exist.
 
@@ -16,26 +16,30 @@ download_checkout(){
   IN="${1}"
   IFS=';' read -ra ADDR <<< "$IN"
 
-  if $clean ; then # delete the repos if requested
-    echo "Removing ${ADDR[0]}"
-    rm -rf ./${ADDR[0]}
+  if [[ $clean = "true" ]] ; then # delete the repos if requested
+    if [[ ! -d "${ADDR[0]}" ]] ; then
+      echo "*** Warning: Directory ${ADDR[0]} does not exist, nothing to delete"
+    else
+      echo "Removing ${ADDR[0]}"
+      rm -rf "./${ADDR[0]}"
+    fi
   fi
 
   # if download is true and directory doesn't exist
-  if [[ $download = true && ! -d ${ADDR[0]} ]] ; then
-    git clone -b ${ADDR[2]} ${ADDR[1]} ${ADDR[0]}
-    cd ${ADDR[0]}
+  if [[ $download = "true" && ! -d "${ADDR[0]}" ]] ; then
+    git clone -b "${ADDR[2]}" "${ADDR[1]}" "${ADDR[0]}"
+    cd "${ADDR[0]}"
 
-    last_date=`date -d ${ADDR[3]} +%s` # convert given date to unix timestamp
+    last_date=`date -d "${ADDR[3]}" +%s` # convert given date to unix timestamp
     # we could simply give the param to git but it understands fewer formats than date
 
     # this checks out the first entry in the list of commit hashes which occur before our date
-    git checkout `git log --date=unix --before=${last_date} --pretty=format:"%H" | head -n 1`
+    git checkout `git log --date=unix --before="${last_date}" --pretty=format:"%H" | head -n 1`
 
     cd ..
-  elif [[ $download = false ]]; then
+  elif [[ $download = "false" ]] ; then
     echo "Download flag not set, skipping ${ADDR[0]}"
-  elif [[ -d ${ADDR[0]} ]] ; then
+  elif [[ -d "${ADDR[0]}" ]] ; then
     echo "Directory exists, skipping ${ADDR[0]}"
   fi
 
@@ -61,13 +65,13 @@ while test $# -gt 0; do
       ;;
     -c|--clean)
       shift
-      clean=true
-      download=true
+      clean="true"
+      download="true"
       ;;
     -d|--delete)
       shift
-      clean=true
-      download=false
+      clean="true"
+      download="false"
       ;;
     -i|--input)
       shift

--- a/scripts/date-snapshot/repos
+++ b/scripts/date-snapshot/repos
@@ -1,0 +1,4 @@
+libtraceevent;https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/;libtraceevent;20220601
+libtracefs;https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/;libtracefs;20220601
+trace-cmd;https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/;master;20220601
+kernel-shark;https://github.com/yordan-karadzhov/kernel-shark-v2.beta.git/;kernelshark;20220601

--- a/scripts/date-snapshot/repos
+++ b/scripts/date-snapshot/repos
@@ -1,4 +1,4 @@
 libtraceevent;https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/;libtraceevent;20220601
 libtracefs;https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/;libtracefs;20220601
 trace-cmd;https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/;master;20220601
-kernel-shark;https://github.com/yordan-karadzhov/kernel-shark-v2.beta.git/;kernelshark;20220601
+kernel-shark;https://git.kernel.org/pub/scm/utils/trace-cmd/kernel-shark.git;kernelshark;20220601


### PR DESCRIPTION
This commit adds a scripts/ directory and the date-snapshot.sh script.
date-snapshot automates the process of checking out the last commit
in a repository before a specific date.

We leverage this tool in the GitHub actions CI to fix the ongoing build
error by locking our build dependencies to a specific date- currently
June 1, 2022. This date can be advanced when the breaking change is
found and fixed in the dependencies.

This commit is the beginning of work to make the trace-cruncher build
fully reproducible for containerization.

Signed-off-by: June Knauth (VMware) <june.knauth@gmail.com>