### PR TITLE
trace-cruncher: Add trace-cruncher CI manual trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ on:
     branches: [tracecruncher, yordan_devel]
   schedule:
     - cron:  '0 15 * * THU'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Sometimes it is very useful to have the ability to manually trigger the
workflow action of the trace-cruncher CI.

Signed-off-by: Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>