### PR TITLE
trace-cruncher: Use tcrunchbase library in ftracepy module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ DOCDIR = ./docs
 
 CC = gcc
 CFLAGS = -fPIC -Wall -Wextra -O2 -g
-LDFLAGS = -shared -lbfd
+LDFLAGS = -shared -lbfd -lrt
 RM = rm -rf
 
 TC_BASE_LIB = tracecruncher/libtcrunchbase.so

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,8 @@ def extension(name, sources, libraries):
 
 def main():
     module_ft = extension(name='tracecruncher.ftracepy',
-                          sources=['src/ftracepy.c', 'src/ftracepy-utils.c', 'src/trace-obj-debug.c'],
-                          libraries=['traceevent', 'tracefs', 'bfd'])
+                          sources=['src/ftracepy.c', 'src/ftracepy-utils.c'],
+                          libraries=['traceevent', 'tracefs', 'tcrunchbase', 'rt'])
 
     cythonize('src/npdatawrapper.pyx', language_level = 3)
     module_data = extension(name='tracecruncher.npdatawrapper',


### PR DESCRIPTION
The recently introduced tcrunchbase library is used for all common code,
that could be reused among different trace-cruncher modules. Use that
library in ftracepy module.

Signed-off-by: Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>