### PR TITLE
trace-cruncher: Update Actions to add a check for regressions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ on:
     - cron:  '0 15 * * THU'
 
 jobs:
-  build:
+  build-test-snapshot:
     runs-on: ubuntu-latest
 
     steps:
@@ -55,3 +55,53 @@ jobs:
       shell: bash
       # Execute tests defined by the CMake configuration.
       run: sudo python3 -m unittest discover .
+
+  build-test-latest:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install Dependencies
+      working-directory: ${{runner.workspace}}/trace-cruncher
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install build-essential git cmake libjson-c-dev binutils-dev -y
+        sudo apt-get install libpython3-dev cython3 python3-numpy -y
+        sudo apt install python3-pip
+        sudo pip3 install --system pkgconfig GitPython
+        cd ./scripts/date-snapshot/
+        bash ./date-snapshot.sh -l -f ./repos
+        cd libtraceevent
+        make
+        sudo make install
+        cd ..
+        cd libtracefs
+        make
+        sudo make install
+        cd ..
+        cd trace-cmd
+        make
+        sudo make install_libs
+        cd ..
+        cd kernel-shark/build
+        cmake ..
+        make
+        sudo make install
+        cd ../..
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/trace-cruncher
+      shell: bash
+      # Build and install.
+      run: |
+        make
+        sudo make install
+
+    - name: Test
+      working-directory: ${{runner.workspace}}/trace-cruncher/tests
+      shell: bash
+      # Execute tests defined by the CMake configuration.
+      run: sudo python3 -m unittest discover .
+


### PR DESCRIPTION
This commit adds a second, independent job to GitHub Actions which runs
date-snapshot with the latest flag. This will allow us to spot regressions
or breaking changes in our dependencies.

The normal build-test job will continue to run with a date snapshot for
reproducibility and stability.

Signed-off-by: June Knauth (VMware) <june.knauth@gmail.com>