### PR TITLE
trace-cruncher: Fix a syntax error in date-snapshot and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ tracecruncher.egg-info/
 dist/
 src/npdatawrapper.c
 install_manifest.txt
+scripts/date-snapshot/libtracefs
+scripts/date-snapshot/libtraceevent
+scripts/date-snapshot/trace-cmd
+scripts/date-snapshot/kernel-shark

--- a/scripts/date-snapshot/date-snapshot.sh
+++ b/scripts/date-snapshot/date-snapshot.sh
@@ -112,7 +112,7 @@ while test $# -gt 0; do
       ;;
     -i|--input)
       shift
-      workdir="${pwd}"
+      workdir="$(pwd)"
       IFS=" "
       while read repo; do
         download_checkout $repo


### PR DESCRIPTION
Parentheses are the correct syntax to call a command, not curly braces.

Additionally, update .gitignore so that the build dependencies downloaded
by date-snapshot are not tracked.

Signed-off-by: June Knauth (VMware) <june.knauth@gmail.com>