### PR TITLE
trace-cruncher: Introduce Docker installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: LGPL-2.1
+# Copyright (C) 2022, VMware Inc, June Knauth <june.knauth@gmail.com>
+
+FROM debian
+# Install APT and pip dependencies
+RUN apt update && apt install build-essential git cmake libjson-c-dev libpython3-dev cython3 python3-numpy python3-pip flex valgrind binutils-dev pkg-config swig curl -y && pip3 install pkgconfig GitPython
+# Download the latest date-snapshot tool from the trace-cruncher GitHub
+# Then use it to download a snapshot of trace-cruncher and its dependencies (defined in repos)
+RUN mkdir build
+WORKDIR build
+RUN curl -o date-snapshot.sh https://raw.githubusercontent.com/vmware/trace-cruncher/tracecruncher/scripts/date-snapshot/date-snapshot.sh &&\
+curl -o repos https://raw.githubusercontent.com/vmware/trace-cruncher/tracecruncher/scripts/date-snapshot/repos &&\
+bash ./date-snapshot.sh -i "trace-cruncher;https://github.com/vmware/trace-cruncher.git;tracecruncher;20220628" &&\
+bash ./date-snapshot.sh -f repos
+# Build kernel tracing libs
+RUN cd libtraceevent && make && make install
+RUN cd libtracefs && make && make install
+RUN cd trace-cmd && make && make install_libs
+RUN cd kernel-shark/build && cmake .. && make && make install
+# Install trace-cruncher
+RUN cd trace-cruncher && make && make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: LGPL-2.1
 # Copyright (C) 2022, VMware Inc, June Knauth <june.knauth@gmail.com>
 
-FROM debian
+FROM debian:bullseye
 # Install APT and pip dependencies
 RUN apt update && apt install build-essential git cmake libjson-c-dev libpython3-dev cython3 python3-numpy python3-pip flex valgrind binutils-dev pkg-config swig curl -y && pip3 install pkgconfig GitPython
 # Download the latest date-snapshot tool from the trace-cruncher GitHub
@@ -20,3 +20,6 @@ RUN cd trace-cmd && make && make install_libs
 RUN cd kernel-shark/build && cmake .. && make && make install
 # Install trace-cruncher
 RUN cd trace-cruncher && make && make install
+# Remove build dependencies; run build with --squash to reduce image size
+RUN cd trace-cruncher && make clean
+RUN pip3 uninstall pkgconfig -y && apt remove build-essential cmake python3-pip libpython3-dev flex valgrind binutils-dev pkg-config swig curl -y && apt autoremove -y

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ To execute the unit tests run the following from the `trace-cruncher/tests` dire
 
 	sudo python3 -m unittest discover .
 
+## Installation via Docker
+
+trace-cruncher can be installed using Docker. Run the following as root from the cloned repository:
+    docker build --no-cache -t trace-cruncher-image - < Dockerfile
+
+We recommend using the `--no-cache` flag to ensure git updates are not missed in the build, as well as the `--squash` flag to shrink the final image size by removing the build dependencies.
+
+When running trace-cruncher as a docker container, the container must be started with the `--privileged` flag to give trace-cruncher access to the host kernel. See below:
+
+    docker run --privileged --name trace-cruncher-container -it trace-cruncher-image
+
 ## Documentation
 For questions about the use of Trace-Cruncher, please send email to: linux-trace-users@vger.kernel.org
 


### PR DESCRIPTION
This PR continues work towards making trace-cruncher fully reproducible and containerized.

The Dockerfile builds a Debian image with trace-cruncher installed, using the new date-snapshot script to freeze the built dependencies as well as trace-cruncher itself.

The next phase of this work will be moving to a Debuerreotype base image so that the container build will be completely reproducible.

Additionally this commit also updates the README with basic Docker install instructions.

Still to-do is to remove build dependencies after the build is complete. Also, the script will need to be updated once the date-snapshot script is changed to use commit tags. It might be worthwhile to create a "repos-docker" file which includes tracecruncher and have the script fetch from that file instead of calling the script twice. For those reasons I am marking this as a draft.

However, I wanted to put in this PR before the long weekend to get feedback on the Dockerfile architecture. As opposed to using the date-snapshot script, it would be possible to lock the version manually in the Dockerfile and `git clone` the repositories directly in the file itself. However, this would mean another place where we need to update our dependencies. I like the idea of having one file to update that we know affects all our builds, both manual and Dockerfile. We might explore environment variables via GitHub itself, which could provide a centralized location for locking versions. Please discuss.

Signed-off-by: June Knauth (VMware) <june.knauth@gmail.com>