### PR TITLE
trace-cruncher: Finish integration of git-snapshot and fix issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,8 +72,8 @@ jobs:
         sudo apt-get install libpython3-dev cython3 python3-numpy -y
         sudo apt install python3-pip
         sudo pip3 install --system pkgconfig GitPython
-        cd ./scripts/date-snapshot/
-        bash ./date-snapshot.sh -l -f ./repos
+        cd ./scripts/git-snapshot/
+        bash ./git-snapshot.sh -l -f ./repos
         cd libtraceevent
         make
         sudo make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,14 +5,14 @@
 FROM debian:bullseye
 # Install APT and pip dependencies
 RUN apt update && apt install build-essential git cmake libjson-c-dev libpython3-dev cython3 python3-numpy python3-pip flex valgrind binutils-dev pkg-config swig curl -y && pip3 install pkgconfig GitPython
-# Download the latest date-snapshot tool from the trace-cruncher GitHub
+# Download the latest git-snapshot tool from the trace-cruncher GitHub
 # Then use it to download a snapshot of trace-cruncher and its dependencies (defined in repos)
 RUN mkdir build
 WORKDIR build
-RUN curl -o date-snapshot.sh https://raw.githubusercontent.com/vmware/trace-cruncher/tracecruncher/scripts/date-snapshot/date-snapshot.sh &&\
-curl -o repos https://raw.githubusercontent.com/vmware/trace-cruncher/tracecruncher/scripts/date-snapshot/repos &&\
-bash ./date-snapshot.sh -i "trace-cruncher;https://github.com/vmware/trace-cruncher.git;tracecruncher;20220628" &&\
-bash ./date-snapshot.sh -f repos
+RUN curl -o git-snapshot.sh https://raw.githubusercontent.com/vmware/trace-cruncher/tracecruncher/scripts/git-snapshot/git-snapshot.sh &&\
+curl -o repos https://raw.githubusercontent.com/vmware/trace-cruncher/tracecruncher/scripts/git-snapshot/repos &&\
+bash ./git-snapshot.sh -l -i "trace-cruncher;https://github.com/vmware/trace-cruncher.git;tracecruncher;" &&\
+bash ./git-snapshot.sh -f repos
 # Build kernel tracing libs
 RUN cd libtraceevent && make && make install
 RUN cd libtracefs && make && make install

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ clean:
 	${RM} $(TC_BASE_LIB)
 	${RM} src/*.o
 	${RM} build
-	bash scripts/date-snapshot/date-snapshot.sh -d -f scripts/date-snapshot/repos
+	bash scripts/git-snapshot/git-snapshot.sh -d -f scripts/git-snapshot/repos
 
 install:
 	@ echo ${CYAN}Installing trace-cruncher:${NC};

--- a/scripts/git-snapshot/git-snapshot.sh
+++ b/scripts/git-snapshot/git-snapshot.sh
@@ -57,10 +57,12 @@ download_checkout(){
     git clone -b "${ADDR[2]}" "${ADDR[1]}" "${workdir}/${ADDR[0]}"
     if [[ $latest = "false" ]] ; then # If latest flag is set, leave repo as-is
       cd "${workdir}/${ADDR[0]}"
-      if [[ git rev-parse --verify "${ADDR[3]}" = "0" ]] ; then # If we can checkout the reference
+      null=$(git rev-parse --verify "${ADDR[3]}") # put STDOUT in a temp var, we only need return value
+      if [[ $? = "0" ]] ; then # If we can checkout the reference
         git checkout "${ADDR[3]}" # Checkout the provided reference
       else
         log_critical "*** Warning: Cannot checkout reference ${ADDR[3]}"
+      fi
       cd "${workdir}"
     else
       log_verbose "Latest flag set, skipping checkout for ${ADDR[0]}"


### PR DESCRIPTION
Fix an issue in Actions where the path of git-snapshot was not updated
properly

Fix a syntax error in git-snapshot causing the script to incorrectly interpret
the result of git rev-parse

Update the Dockerfile to account for the git-snapshot changes and switch
the Dockerfile to use the latest trace-cruncher while we are still
integrating Docker and finalizing the Dockerfile. Once we reach a stable
point this can be updated to use a snapshot again.

Update the Makefile with the correct path of git-snapshot

Signed-off-by: June Knauth (VMware) <june.knauth@gmail.com>