### PR TITLE
trace-cruncher: Update git CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get install build-essential git cmake libjson-c-dev binutils-dev -y
         sudo apt-get install libpython3-dev cython3 python3-numpy -y
         sudo apt install python3-pip
-        sudo pip3 install --system pkgconfig GitPython
+        sudo pip3 install --system pkgconfig GitPython psutil
         cd ./scripts/git-snapshot/
         bash ./git-snapshot.sh -f ./repos
         cd libtraceevent
@@ -71,7 +71,7 @@ jobs:
         sudo apt-get install build-essential git cmake libjson-c-dev binutils-dev -y
         sudo apt-get install libpython3-dev cython3 python3-numpy -y
         sudo apt install python3-pip
-        sudo pip3 install --system pkgconfig GitPython
+        sudo pip3 install --system pkgconfig GitPython psutil
         cd ./scripts/git-snapshot/
         bash ./git-snapshot.sh -l -f ./repos
         cd libtraceevent


### PR DESCRIPTION
The psutil python package is needed by the latest changes.
