### PR TITLE
tracetrace-cruncher: Update github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install Dependencies
       working-directory: ${{runner.workspace}}/trace-cruncher
@@ -22,7 +22,7 @@ jobs:
         sudo apt-get install build-essential git cmake libjson-c-dev binutils-dev -y
         sudo apt-get install libpython3-dev cython3 python3-numpy -y
         sudo apt install python3-pip
-        sudo pip3 install --system pkgconfig GitPython psutil
+        sudo pip3 install pkgconfig GitPython psutil
         cd ./scripts/git-snapshot/
         bash ./git-snapshot.sh -f ./repos
         cd libtraceevent
@@ -71,7 +71,7 @@ jobs:
         sudo apt-get install build-essential git cmake libjson-c-dev binutils-dev -y
         sudo apt-get install libpython3-dev cython3 python3-numpy -y
         sudo apt install python3-pip
-        sudo pip3 install --system pkgconfig GitPython psutil
+        sudo pip3 install pkgconfig GitPython psutil
         cd ./scripts/git-snapshot/
         bash ./git-snapshot.sh -l -f ./repos
         cd libtraceevent


### PR DESCRIPTION
Updated actions to version 3, as the old one uses Node.js 12 which is deprecated.
Removed "--system" flag from "pip3 install", as it is nod needed and not supported in the latest Ubuntu.

Signed-off-by: Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>