### PR TITLE
trace-cruncher: Update dependences

### DIFF
--- a/scripts/git-snapshot/repos
+++ b/scripts/git-snapshot/repos
@@ -1,4 +1,4 @@
-libtraceevent;https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/;libtraceevent;libtraceevent-1.6.3
-libtracefs;https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/;libtracefs;libtracefs-1.5.0
-trace-cmd;https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/;master;trace-cmd-v3.1.3
-kernel-shark;https://git.kernel.org/pub/scm/utils/trace-cmd/kernel-shark.git;kernelshark;kernelshark-v2.1.1
+libtraceevent;https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/;libtraceevent;libtraceevent-1.7.1
+libtracefs;https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/;libtracefs;libtracefs-1.6.4
+trace-cmd;https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/;master;trace-cmd-v3.1.6
+kernel-shark;https://git.kernel.org/pub/scm/utils/trace-cmd/kernel-shark.git;kernelshark;kernelshark-v2.2.0


### PR DESCRIPTION
Use the latest versions of libtraceevent, libtracefs, trace-cmd and kernel-shark when building the docker image.

Signed-off-by: Tzvetomir Stoyanov (VMware) <tz.stoyanov@gmail.com>