### PR TITLE
trace-cruncher: Replace permission error with warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ uninstall:
 doc:
 	@ echo ${CYAN}Buildinging trace-cruncher documentation:${NC};
 	@ python3 $(DOCDIR)/setup.py builtins
-	@ sudo python3 $(DOCDIR)/setup.py tracecruncher.ftracepy $(UID) $(GID)
-	@ sudo python3 $(DOCDIR)/setup.py tracecruncher.ft_utils $(UID) $(GID)
+	@ python3 $(DOCDIR)/setup.py tracecruncher.ftracepy $(UID) $(GID)
+	@ python3 $(DOCDIR)/setup.py tracecruncher.ft_utils $(UID) $(GID)
 
 clean_doc:
 	@ rm -f $(DOCDIR)/*.html

--- a/src/ftracepy.c
+++ b/src/ftracepy.c
@@ -646,9 +646,8 @@ PyMODINIT_FUNC PyInit_ftracepy(void)
 	PyModule_AddObject(module, "tc_error", TRACECRUNCHER_ERROR);
 
 	if (geteuid() != 0) {
-		PyErr_SetString(TFS_ERROR,
-				"Permission denied. Root privileges are required.");
-		return NULL;
+		PyErr_WarnEx(TFS_ERROR,
+			     "Permission alert - access to the tracing subsystem requires root privileges.", 1);
 	}
 
 	Py_AtExit(PyFtrace_at_exit);


### PR DESCRIPTION
Access to the ftarce subsystem requires root privilege, trace-cruncher cannot be used without it. There is a check for that at module load and fatal error is triggered. However, there are cases where the module is loading for some other purposes as non-root, for example when the documentation is generated. This should be possible without root privilege.
Replaced the error with warning, so the module can be loaded by regular user. However, a warning is printed in such cases.