### PR TITLE
trace-cruncher: Bump the versions of required trace libraries

### DIFF
--- a/scripts/git-snapshot/repos
+++ b/scripts/git-snapshot/repos
@@ -1,4 +1,4 @@
-libtraceevent;https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/;libtraceevent;libtraceevent-1.7.1
-libtracefs;https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/;libtracefs;libtracefs-1.6.4
-trace-cmd;https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/;master;trace-cmd-v3.1.6
+libtraceevent;https://git.kernel.org/pub/scm/libs/libtrace/libtraceevent.git/;libtraceevent;libtraceevent-1.7.3
+libtracefs;https://git.kernel.org/pub/scm/libs/libtrace/libtracefs.git/;libtracefs;libtracefs-1.7
+trace-cmd;https://git.kernel.org/pub/scm/utils/trace-cmd/trace-cmd.git/;master;trace-cmd-v3.2
 kernel-shark;https://git.kernel.org/pub/scm/utils/trace-cmd/kernel-shark.git;kernelshark;kernelshark-v2.2.0

--- a/setup.py
+++ b/setup.py
@@ -39,8 +39,8 @@ def add_library(lib, min_version,
 def third_party_paths():
     library_dirs = ['$ORIGIN','tracecruncher']
     include_dirs = [np.get_include()]
-    libs_required = [('libtraceevent', '1.5.0'),
-                     ('libtracefs',    '1.4.1'),
+    libs_required = [('libtraceevent', '1.7.3'),
+                     ('libtracefs',    '1.7.0'),
                      ('libkshark',     '2.0.1')]
     libs_found = []
 


### PR DESCRIPTION
New version of libtraceevent, libtracefs and libtracecmd were released recently, with fixes, improvements and new APIs. The newly introduced functionality will be very useful for trace-cruncher.
 libtraceevent-1.7.3
 libtracefs-1.7.0
 trace-cmd-v3.2.0