### PR TITLE
trace-cruncher: Makefile target for unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,14 @@ $(PY_SETUP):
 $(TC_BASE_LIB): $(BASE_OBJS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
 
+test:
+ifneq ($(UID), 0)
+	$(error Unit tests must be executed with root privileges, access to the ftrace system is required)
+endif
+	$(warning trace-cruncher under test must be installed on the system before running these tests.)
+	$(info Running unit tests:)
+	cd tests && python3 -m unittest discover .
+
 clean:
 	${RM} src/npdatawrapper.c
 	${RM} $(TC_BASE_LIB)


### PR DESCRIPTION
Trace-cruncher has unit tests, which can be run manually from the tests directory with the command
  python3 -m unittest discover .
However, having a dedicated Makefile target to run these tests is useful and simplifies the testing. Added a new "make test" target.