### PR TITLE
TraceCruncher: Version 0.4.0 (Beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## [Release v0.4.0](https://github.com/vmware/trace-cruncher/compare/tracecruncher-v0.3.0...tracecruncher-v0.4.0)
+
+> Release Date: 2023-06-26
+
+ ### API Changes
+- [40f3340b]	trace-cruncher: New API to get available dynamic events
+- [edc58ef3]	trace-cruncher: New API to get available trace instances
+- [71c5305e]	trace-cruncher: Improve synthetic events creation
+- [03a87012]	trace-cruncher: Improve trace instance deletion
+
+ ### Tests
+- [c590c196]	trace-cruncher: Makefile target for unit tests
+
+ ### Chore
+- [3a4e9ebb]	trace-cruncher: Bump the versions of required trace libraries
+- [02f9b380]	trace-cruncher: Fixed compilation warnings
+- [461c340e]	trace-cruncher: Replace permission error with warning
+- [882ab136]	trace-cruncher: Update dependences
+- [4f028cf5]	tracetrace-cruncher: Update github workflow
+
 ## [Release v0.3.0](https://github.com/vmware/trace-cruncher/compare/tracecruncher-v0.2.0...tracecruncher-v0.3.0)
 
 > Release Date: 2022-11-22

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def main():
                           libraries=['kshark'])
 
     setup(name='tracecruncher',
-          version='0.3.0',
+          version='0.4.0',
           description='Interface for accessing Linux tracing data in Python.',
           author='Yordan Karadzhov (VMware)',
           author_email='y.karadz@gmail.com',


### PR DESCRIPTION
Changes in the new version:
 - New API to get available dynamic events.
 - New API to get available trace instances.
 - Improve synthetic events creation. Now synthetic events can be created in the scope of a trace instance.
 - Improve trace instance deletion - new API for trace instance reset.
 - Allow the library to be loaded from a non-privileged user context. Although starting a trace session requires root access to the system, running as non-root is useful in cases when the library documentation is generated.
 - New makefile target for running the unit tests.
 - Aligned with latest versions of the trace libraries tracefs and traceevent.

Look at the changelog for the full list of changes.