### PR TITLE
trace-cruncher: Version 0.4.1 (Beta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## [Release v0.4.0](https://github.com/vmware/trace-cruncher/compare/tracecruncher-v0.3.0...tracecruncher-v0.4.0)
+## [Release v0.4.1](https://github.com/vmware/trace-cruncher/compare/tracecruncher-v0.3.0...tracecruncher-v0.4.1)
+
+> Release Date: 2023-07-03
+ ### Chore
+- [02539f0d]   trace-cruncher: Fixed libtracefs version
 
 > Release Date: 2023-06-26
 

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def main():
                           libraries=['kshark'])
 
     setup(name='tracecruncher',
-          version='0.4.0',
+          version='0.4.1',
           description='Interface for accessing Linux tracing data in Python.',
           author='Yordan Karadzhov (VMware)',
           author_email='y.karadz@gmail.com',


### PR DESCRIPTION
Changes in the new version:
 - Fixed libtracefs version.